### PR TITLE
Update index.d.ts to fix compilation error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ declare module "jspdf" {
 ...now matches the npm package name
 
 ```typescript
-declare module "@zendostrike/jsPDF-html2canvas-pro" {
+declare module "@colinng/jsPDF-html2canvas-pro" {
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
+This is a fork of:
+
+- [npm @zendostrike/jspdf-html2canvas-pro](https://www.npmjs.com/package/@zendostrike/jspdf-html2canvas-pro)
+- [GitHub: zendostrike/jsPDF-html2canvas-pro](https://github.com/zendostrike/jsPDF-html2canvas-pro)
+
+to fix the compilation error
+
+```error
+File '.../node_modules/@zendostrike/jsPDF-html2canvas-pro/types/index.d.ts' is not a module.
+```
+
+by changing `/types/index.d.ts` so the module name...
+
+```typescript
+declare module "jspdf" {
+```
+
+...now matches the npm package name
+
+```typescript
+declare module "@zendostrike/jsPDF-html2canvas-pro" {
+```
+
+---
+
+zendostrike's ReadMe:
+
 > [!CAUTION]
 > Do not use this on a production environment
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -49,7 +49,7 @@
  *    kim3er, mfo, alnorth, Flamenco
  */
 
-declare module "@zendostrike/jsPDF-html2canvas-pro" {
+declare module "@colinng/jsPDF-html2canvas-pro" {
   export interface Annotation {
     type: "text" | "freetext" | "link";
     title?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -49,7 +49,7 @@
  *    kim3er, mfo, alnorth, Flamenco
  */
 
-declare module "jspdf" {
+declare module "@zendostrike/jsPDF-html2canvas-pro" {
   export interface Annotation {
     type: "text" | "freetext" | "link";
     title?: string;


### PR DESCRIPTION
Update index.d.ts to fix compilation error.

```error
File '.../node_modules/@zendostrike/jsPDF-html2canvas-pro/types/index.d.ts' is not a module.
```